### PR TITLE
Implement IPv6 FirstFit6 helper

### DIFF
--- a/SubnetCalculator/MainWindow.xaml.cs
+++ b/SubnetCalculator/MainWindow.xaml.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using System.Numerics;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Input;
@@ -410,6 +411,33 @@ namespace SubnetCalculator
                 for (int j = 1; j < subs.Count; j++) pool.Add(subs[j]);
 
                 pool.Sort((a, b) => IPToUInt(a.Network).CompareTo(IPToUInt(b.Network)));
+                return subs[0];
+            }
+            return null;
+        }
+
+        private static IPv6Network? FirstFit6(List<IPv6Network> pool, int pref)
+        {
+            static BigInteger IpToBig(System.Net.IPAddress ip)
+            {
+                var bytes = ip.GetAddressBytes();
+                Array.Reverse(bytes);
+                var arr = new byte[bytes.Length + 1];
+                Array.Copy(bytes, 0, arr, 1, bytes.Length);
+                return new BigInteger(arr);
+            }
+
+            for (int i = 0; i < pool.Count; i++)
+            {
+                var blk = pool[i];
+                if (blk.Cidr > pref) continue;
+                var subs = blk.Subnet(pref).ToList();
+                if (!subs.Any()) continue;
+
+                pool.RemoveAt(i);
+                for (int j = 1; j < subs.Count; j++) pool.Add(subs[j]);
+
+                pool.Sort((a, b) => IpToBig(a.Network).CompareTo(IpToBig(b.Network)));
                 return subs[0];
             }
             return null;


### PR DESCRIPTION
## Summary
- add `System.Numerics` reference
- implement `FirstFit6` to allocate IPv6 subnets using big integer sorting

## Testing
- `dotnet build SubnetCalculator.sln -warnaserror` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848028204a4832794522b57ae18ad97