### PR TITLE
Add IPv6 subnet allocation feature

### DIFF
--- a/SubnetCalculator/IPv6Network.cs
+++ b/SubnetCalculator/IPv6Network.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Numerics;
+
+namespace SubnetCalculator
+{
+    public class IPv6Network
+    {
+        public IPAddress Network { get; }
+        public int Cidr { get; }
+
+        private IPv6Network(IPAddress net, int cidr)
+        {
+            Network = net;
+            Cidr = cidr;
+        }
+
+        /*──────── parsing ────────*/
+        public static IPv6Network Parse(string s)
+        {
+            var parts = s.Trim().Split(new[] { ' ', '/' }, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length == 0) throw new FormatException("Empty string.");
+
+            IPAddress ip = IPAddress.Parse(parts[0]);
+            if (ip.AddressFamily != System.Net.Sockets.AddressFamily.InterNetworkV6)
+                throw new FormatException("Not an IPv6 address.");
+            int prefix;
+
+            if (parts.Length == 2)
+            {
+                prefix = int.Parse(parts[1]);
+            }
+            else
+            {
+                prefix = TightestAlignedPrefix(ip);
+            }
+
+            if (prefix < 0 || prefix > 128)
+                throw new FormatException("Invalid prefix.");
+
+            BigInteger netBig = IPToBigInteger(ip) & PrefixToMaskBI(prefix);
+            return new IPv6Network(BigIntegerToIP(netBig), prefix);
+        }
+
+        /*──────── subnetting ─────*/
+        public IEnumerable<IPv6Network> Subnet(int newPrefix)
+        {
+            if (newPrefix < Cidr || newPrefix < 0 || newPrefix > 128)
+                throw new ArgumentException("newPrefix must be between current prefix and 128");
+            BigInteger blocks = BigInteger.One << (newPrefix - Cidr);
+            BigInteger size = BigInteger.One << (128 - newPrefix);
+            BigInteger start = IPToBigInteger(Network);
+            for (BigInteger i = BigInteger.Zero; i < blocks; i++)
+                yield return new IPv6Network(BigIntegerToIP(start + size * i), newPrefix);
+        }
+
+        /*──────── helpers ────────*/
+        private static int TightestAlignedPrefix(IPAddress ip)
+        {
+            BigInteger v = IPToBigInteger(ip);
+            for (int p = 1; p <= 127; p++)
+            {
+                BigInteger mask = PrefixToMaskBI(p);
+                if ((v & mask) == v)
+                    return p;
+            }
+            return 128;
+        }
+
+        public static BigInteger PrefixToMaskBI(int p)
+        {
+            if (p == 0) return BigInteger.Zero;
+            return ((BigInteger.One << p) - BigInteger.One) << (128 - p);
+        }
+
+        public static IPAddress BigIntegerToIP(BigInteger v)
+        {
+            var bytes = v.ToByteArray(isUnsigned: true, isBigEndian: true);
+            if (bytes.Length < 16)
+                bytes = Enumerable.Repeat((byte)0, 16 - bytes.Length).Concat(bytes).ToArray();
+            return new IPAddress(bytes);
+        }
+
+        public static BigInteger IPToBigInteger(IPAddress ip)
+        {
+            var bytes = ip.GetAddressBytes();
+            if (bytes.Length != 16)
+                throw new FormatException("Not IPv6");
+            return new BigInteger(bytes, isUnsigned: true, isBigEndian: true);
+        }
+    }
+}

--- a/SubnetCalculator/MainWindow.xaml
+++ b/SubnetCalculator/MainWindow.xaml
@@ -320,6 +320,82 @@
                 </Grid>
             </TabItem>
 
+            <!--════════ TAB 3 – IPv6 ════════-->
+            <TabItem Header="IPv6">
+                <Grid Margin="12">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+
+                    <StackPanel Orientation="Horizontal" Margin="0 0 0 10">
+                        <TextBlock VerticalAlignment="Center" FontWeight="SemiBold">Starting network:</TextBlock>
+                        <TextBox x:Name="Ipv6StartBox" Width="320" Margin="8 0 0 0"/>
+
+                        <TextBlock VerticalAlignment="Center" FontWeight="SemiBold" Margin="25 0 0 0">Prefix (optional):</TextBlock>
+                        <TextBox x:Name="Ipv6MaskBox" Width="80" Margin="8 0 0 0"/>
+
+                        <Button Content="Add row"      Click="OnAddRequest6"   Margin="30 0 0 0"/>
+                        <Button Content="Remove row"   Click="OnRemoveRequest6" Margin="8 0 0 0"/>
+                        <Button Content="Calculate"    Click="OnCalculateIpv6" Margin="30 0 0 0"/>
+                    </StackPanel>
+
+                    <DataGrid x:Name="RequestGrid6"
+                          Grid.Row="1" Margin="0 0 0 10"
+                          AutoGenerateColumns="False"
+                          CanUserAddRows="False"
+                          SelectionMode="Single" SelectionUnit="FullRow"
+                          MouseDoubleClick="OnCopyCell"
+                          RowStyle="{StaticResource RowHighlight}"
+                          CellStyle="{StaticResource CellHighlight}"
+                          Background="{DynamicResource CtrlBg}"
+                          RowBackground="{DynamicResource CtrlBg}"
+                          AlternatingRowBackground="{DynamicResource AltBg}">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Label"     Binding="{Binding Label}"     Width="150"/>
+                            <DataGridTextColumn Header="Prefix"    Binding="{Binding Prefix}"    Width="80" ElementStyle="{StaticResource RightCell}"/>
+                            <DataGridTextColumn Header="Interface" Binding="{Binding Interface}" Width="130"/>
+                            <DataGridTextColumn Header="Notes"     Binding="{Binding Notes}"     Width="*"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+
+                    <Border Grid.Row="2" Background="{DynamicResource CtrlBg}" CornerRadius="{StaticResource Corner4}" Padding="8" Margin="0 6">
+                        <TextBlock x:Name="SummaryIpv6" FontWeight="SemiBold"/>
+                    </Border>
+
+                    <DataGrid x:Name="ResultGridIpv6"
+                          Grid.Row="3" Margin="0 4"
+                          AutoGenerateColumns="False"
+                          IsReadOnly="True"
+                          CanUserAddRows="False"
+                          EnableRowVirtualization="True"
+                          SelectionMode="Single" SelectionUnit="FullRow"
+                          MouseDoubleClick="OnCopyCell"
+                          RowStyle="{StaticResource RowHighlight}"
+                          CellStyle="{StaticResource CellHighlight}"
+                          Background="{DynamicResource CtrlBg}"
+                          RowBackground="{DynamicResource CtrlBg}"
+                          AlternatingRowBackground="{DynamicResource AltBg}">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="#"      Binding="{Binding Index}"     Width="55"  ElementStyle="{StaticResource RightCell}"/>
+                            <DataGridTextColumn Header="Label"  Binding="{Binding Label}"     Width="120"/>
+                            <DataGridTextColumn Header="Intf"   Binding="{Binding Interface}" Width="110"/>
+                            <DataGridTextColumn Header="Network" Binding="{Binding Network}"  Width="280" ElementStyle="{StaticResource RightCell}"/>
+                            <DataGridTextColumn Header="Prefix" Binding="{Binding Prefix}"   Width="80"  ElementStyle="{StaticResource RightCell}"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+
+                    <StackPanel Orientation="Horizontal" Grid.Row="4" HorizontalAlignment="Right" Margin="0 6 0 0">
+                        <Button Content="Export CSV"  Click="OnExportCsvIpv6"  Margin="0 0 8 0"/>
+                        <Button Content="Export JSON" Click="OnExportJsonIpv6"/>
+                    </StackPanel>
+                </Grid>
+            </TabItem>
+
         </TabControl>
     </DockPanel>
 </Window>

--- a/SubnetCalculator/MainWindow.xaml.cs
+++ b/SubnetCalculator/MainWindow.xaml.cs
@@ -15,6 +15,7 @@ using System.Windows;
 using System.Windows.Media;
 using System.Windows.Input;
 using System.Windows.Controls;
+using System.Numerics;
 
 namespace SubnetCalculator
 {
@@ -24,11 +25,14 @@ namespace SubnetCalculator
         private List<IPNetwork> _fixed = new();
         private readonly ObservableCollection<SubnetRequest> _req = new();
         private List<SubnetAllocation> _alloc = new();
+        private readonly ObservableCollection<Ipv6SubnetRequest> _req6 = new();
+        private List<Ipv6SubnetAllocation> _alloc6 = new();
 
         public MainWindow()
         {
             InitializeComponent();
             RequestGrid.ItemsSource = _req;
+            RequestGrid6.ItemsSource = _req6;
             ApplyTheme(light: false);                         // DARK by default
         }
 
@@ -135,10 +139,26 @@ namespace SubnetCalculator
         }
         private sealed record SubnetAllocation(int Index, string Label, string Interface, IPNetwork Net);
 
+        private sealed class Ipv6SubnetRequest
+        {
+            public string Label { get; set; } = "Site";
+            public int Prefix { get; set; } = 64;
+            public string Interface { get; set; } = "";
+            public string Notes { get; set; } = "";
+        }
+
+        private sealed record Ipv6SubnetAllocation(int Index, string Label, string Interface, IPv6Network Net);
+
         private void OnAddRequest(object? s, RoutedEventArgs e) => _req.Add(new SubnetRequest());
         private void OnRemoveRequest(object? s, RoutedEventArgs e)
         {
             if (RequestGrid.SelectedItem is SubnetRequest r) _req.Remove(r);
+        }
+
+        private void OnAddRequest6(object? s, RoutedEventArgs e) => _req6.Add(new Ipv6SubnetRequest());
+        private void OnRemoveRequest6(object? s, RoutedEventArgs e)
+        {
+            if (RequestGrid6.SelectedItem is Ipv6SubnetRequest r) _req6.Remove(r);
         }
 
         private void OnCalculateVlsm(object? s, RoutedEventArgs e) => Guarded(() =>
@@ -211,6 +231,52 @@ namespace SubnetCalculator
         private void OnCopyAclVlsm(object? s, RoutedEventArgs e) => Guarded(() =>
             CopyAcl(_alloc.Select(a => (a.Net.Network, a.Net.Cidr))));
         private void OnExportCliVlsm(object? s, RoutedEventArgs e) => Guarded(() => ExportCli());
+
+        /*════════════════  IPv6 TAB  ════════════════*/
+        private void OnCalculateIpv6(object? s, RoutedEventArgs e) => Guarded(() =>
+        {
+            string startTxt = Ipv6StartBox.Text.Trim();
+            string maskTxt = Ipv6MaskBox.Text.Trim();
+
+            if (string.IsNullOrWhiteSpace(startTxt))
+                throw new Exception("Starting network is required.");
+
+            if (!string.IsNullOrWhiteSpace(maskTxt))
+            {
+                if (maskTxt.StartsWith("/"))
+                    startTxt += maskTxt;
+                else
+                    startTxt += "/" + maskTxt;
+            }
+
+            _alloc6.Clear();
+            IPv6Network baseNet = IPv6Network.Parse(startTxt);
+            var pool = new List<IPv6Network> { baseNet };
+
+            var ordered = _req6.OrderBy(r => r.Prefix).ToList();
+            foreach (var r in ordered)
+            {
+                var blk = FirstFit6(pool, r.Prefix) ?? throw new Exception($"Not enough space for '{r.Label}'.");
+                _alloc6.Add(new(_alloc6.Count + 1, r.Label, r.Interface, blk));
+            }
+
+            ResultGridIpv6.ItemsSource = _alloc6.Select(RowIpv6).ToList();
+            SummaryIpv6.Text = $"Allocated {_alloc6.Count} blocks – Pool {pool.Count} blocks";
+        });
+
+        private static object RowIpv6(Ipv6SubnetAllocation a) => new
+        {
+            a.Index,
+            a.Label,
+            a.Interface,
+            Network = a.Net.Network,
+            Prefix = "/" + a.Net.Cidr
+        };
+
+        private void OnExportCsvIpv6(object? s, RoutedEventArgs e) => Guarded(() =>
+            ExportCsv(_alloc6.Select(RowIpv6), "ipv6"));
+        private void OnExportJsonIpv6(object? s, RoutedEventArgs e) => Guarded(() =>
+            ExportJson(_alloc6.Select(RowIpv6), "ipv6"));
 
         /*════════════════  CSV / JSON EXPORT HELPERS  ════════════════*/
         private static void ExportCsv(IEnumerable rows, string tag)
@@ -410,6 +476,24 @@ namespace SubnetCalculator
                 for (int j = 1; j < subs.Count; j++) pool.Add(subs[j]);
 
                 pool.Sort((a, b) => IPToUInt(a.Network).CompareTo(IPToUInt(b.Network)));
+                return subs[0];
+            }
+            return null;
+        }
+
+        private static IPv6Network? FirstFit6(List<IPv6Network> pool, int pref)
+        {
+            for (int i = 0; i < pool.Count; i++)
+            {
+                var blk = pool[i];
+                if (blk.Cidr > pref) continue;
+                var subs = blk.Subnet(pref).ToList();
+                if (!subs.Any()) continue;
+
+                pool.RemoveAt(i);
+                for (int j = 1; j < subs.Count; j++) pool.Add(subs[j]);
+
+                pool.Sort((a, b) => IPv6Network.IPToBigInteger(a.Network).CompareTo(IPv6Network.IPToBigInteger(b.Network)));
                 return subs[0];
             }
             return null;


### PR DESCRIPTION
## Summary
- support IPv6 subnet allocations
- implement `IPv6Network` helper class
- add IPv6 tab in UI with request grid
- handle IPv6 requests and allocations in code-behind

## Testing
- `dotnet build SubnetCalculator.sln -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848027b7a1c832794f0ca51c8e5a28f